### PR TITLE
Added validation for empty textview

### DIFF
--- a/Classes/ios/BORChatRoom.m
+++ b/Classes/ios/BORChatRoom.m
@@ -263,6 +263,10 @@ static const int BORChatRoomDefaultSpacing = 10;
 }
 
 - (void)addMessage:(id <BORChatMessage>)message scrollToMessage:(BOOL)scrollToMessage {
+    if([_messageTextView.text length] == 0)
+    {
+        return;
+    }
     [self.chatCollectionViewController addMessage:message scrollToMessage:scrollToMessage];
 }
 


### PR DESCRIPTION
The send button was creating empty chat bubbles every time it was pressed.  Added some quick validation in the BORChatRoom.m file to only send a message if the textview contains text or space.

Great project, really clean interface!
